### PR TITLE
Fix Invoke-TmfAccessPackageCatalog and Dependencies

### DIFF
--- a/TMF/TMF.psd1
+++ b/TMF/TMF.psd1
@@ -24,7 +24,7 @@
 	PowerShellVersion = '5.1'
 	
 	# Modules that must be imported into the global environment prior to importing this module
-	RequiredModules = @(@{ ModuleName='PSFramework'; ModuleVersion='1.5.171' }, 'Microsoft.Graph.Authentication', 'Microsoft.Graph.Identity.DirectoryManagement')
+	RequiredModules = @(@{ ModuleName='PSFramework'; ModuleVersion='1.5.171' }, 'Microsoft.Graph.Authentication', 'Microsoft.Graph.Identity.DirectoryManagement', 'Microsoft.Graph.Identity.Governance')
 	
 	# Assemblies that must be loaded prior to importing this module
 	# RequiredAssemblies = @('bin\TMF.dll')

--- a/TMF/functions/entitlementManagement/accessPackageCatalogs/Invoke-TmfAccessPackageCatalog.ps1
+++ b/TMF/functions/entitlementManagement/accessPackageCatalogs/Invoke-TmfAccessPackageCatalog.ps1
@@ -24,10 +24,10 @@ function Invoke-TmfAccessPackageCatalog
 	{
 		if (Test-PSFFunctionInterrupt) { return }
 		if ($SpecificResources) {
-        	$testResults = Test-TmfAccessPackage -SpecificResources $SpecificResources -Cmdlet $Cmdlet
+        	$testResults = Test-TmfAccessPackageCatalog -SpecificResources $SpecificResources -Cmdlet $Cmdlet
 		}
 		else {
-			$testResults = Test-TmfAccessPackage -Cmdlet $Cmdlet
+			$testResults = Test-TmfAccessPackageCatalog -Cmdlet $Cmdlet
 		}
 
 		foreach ($result in $testResults) {


### PR DESCRIPTION
Test statement in  Invoke-TmfAccessPackageCatalog was using  Invole-TmfAccessPackage and resulting in no resources getting created,

Changed to use  Invoke-TmfAccessPackageCatalog on lines 27 and 30 has fixed this issue

Addresses issue #6 