### PR TITLE
Update validation set for accesspackageassignment policy

### DIFF
--- a/TMF/functions/entitlementManagement/accessPackageAssignmentPolicies/Register-TmfAccessPackageAssignmentPolicy.ps1
+++ b/TMF/functions/entitlementManagement/accessPackageAssignmentPolicies/Register-TmfAccessPackageAssignmentPolicy.ps1
@@ -16,7 +16,7 @@ function Register-TmfAccessPackageAssignmentPolicy
 		[string] $accessPackage,
 		[Parameter(Mandatory = $true, ParameterSetName = "autoAssigned")]
 		[Parameter(Mandatory = $true, ParameterSetName = "assigned")]
-		[ValidateSet("specificDirectoryUsers","specificConnectedOrganizationUsers","specificDirectoryServicePrincipals","allMemberUsers","allDirectoryUsers","allDirectoryServicePrincipals","allConfiguredConnectedOrganizationUsers","allExternalUsers")]
+		[ValidateSet("notSpecified", "specificDirectoryUsers", "specificConnectedOrganizationUsers", "specificDirectoryServicePrincipals", "allMemberUsers", "allDirectoryUsers", "allDirectoryServicePrincipals", "allConfiguredConnectedOrganizationUsers", "allExternalUsers", "unknownFutureValue")]
 		[string] $allowedTargetScope,
 		[Parameter(Mandatory = $true, ParameterSetName = "autoAssigned")]
 		[Parameter(ParameterSetName = "assigned")]


### PR DESCRIPTION
## Summary

Synchronises the `allowedTargetScope` parameter validation in line with MSGraph specification

https://learn.microsoft.com/en-us/graph/api/resources/accesspackageassignmentpolicy?view=graph-rest-1.0